### PR TITLE
feat: admin dashboard with event-driven rotation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,9 @@ WA_AUTH_BUCKET=recole-485714-room-bot-wa-auth
 # Workspace ID (multi-tenant identifier)
 WORKSPACE_ID=pgma
 
+# Admin dashboard token (shared secret for /admin/:workspaceId)
+ADMIN_TOKEN=change-me-to-a-random-string
+
 # Cloud Run service URL (for approval links in WhatsApp messages)
 # Set after first deploy, or use localhost for local dev
 SERVICE_URL=http://localhost:8080

--- a/infra/deploy.sh
+++ b/infra/deploy.sh
@@ -20,7 +20,7 @@ gcloud run deploy "${SERVICE_NAME}" \
   --region="${REGION}" \
   --source=. \
   --service-account="${SA_EMAIL}" \
-  --set-env-vars="GCP_PROJECT_ID=${PROJECT_ID},WA_AUTH_BUCKET=${BUCKET_NAME},WORKSPACE_ID=pgma" \
+  --set-env-vars="GCP_PROJECT_ID=${PROJECT_ID},WA_AUTH_BUCKET=${BUCKET_NAME},WORKSPACE_ID=pgma,ADMIN_TOKEN=${ADMIN_TOKEN:?Set ADMIN_TOKEN env var before deploying}" \
   --set-secrets="ANTHROPIC_API_KEY=anthropic-api-key:latest" \
   --timeout=120 \
   --memory=512Mi \

--- a/scripts/seed-students.ts
+++ b/scripts/seed-students.ts
@@ -69,6 +69,7 @@ async function seedWorkspace(ws: SeedWorkspace): Promise<void> {
     type: ws.rotation.type,
     order: studentIds,
     currentIndex: 0,
+    deferred: [],
     weeklySlots: ws.rotation.weeklySlots,
   });
 

--- a/src/ai/message-generator.ts
+++ b/src/ai/message-generator.ts
@@ -59,10 +59,13 @@ function buildUserPrompt(ctx: ReminderContext): string {
   if (ctx.events.length > 0) {
     lines.push('', 'Eventos:');
     for (const ev of ctx.events) {
-      const assigned = ev.assignedTo
-        ? ` (asignado a: ${resolveStudentName(ev.assignedTo, ctx.students)})`
-        : '';
-      lines.push(`- ${ev.date} | ${ev.type} | ${ev.description}${assigned}`);
+      lines.push(`- ${ev.date} | ${ev.type} | ${ev.description}`);
+      for (const item of ev.items) {
+        const assignedName = item.assignedTo
+          ? resolveStudentName(item.assignedTo, ctx.students)
+          : 'sin asignar';
+        lines.push(`  * ${item.name}: ${assignedName}`);
+      }
     }
   }
 

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -50,6 +50,7 @@ export const EnvSchema = z.object({
   GCP_PROJECT_ID: z.string().min(1),
   WA_AUTH_BUCKET: z.string().min(1),
   WORKSPACE_ID: z.string().min(1),
+  ADMIN_TOKEN: z.string().min(1),
   PORT: z.string().default('8080'),
 });
 

--- a/src/data/firestore.ts
+++ b/src/data/firestore.ts
@@ -3,6 +3,9 @@ import type {
   ClassEvent,
   Draft,
   DraftStatus,
+  EventItem,
+  EventStatus,
+  EventType,
   ReminderType,
   RotationConfig,
   Student,
@@ -53,20 +56,14 @@ export class WorkspaceStore {
     if (!doc.exists) {
       throw new Error(`Rotation config not found: ${this.workspaceId}`);
     }
-    return doc.data() as RotationConfig;
-  }
-
-  async advanceRotation(steps: number): Promise<number> {
-    const ref = this.db.doc(`workspaces/${this.workspaceId}/rotation/config`);
-    const newIndex = await this.db.runTransaction(async (tx) => {
-      const doc = await tx.get(ref);
-      if (!doc.exists) throw new Error('Rotation config not found');
-      const data = doc.data() as RotationConfig;
-      const next = (data.currentIndex + steps) % data.order.length;
-      tx.update(ref, { currentIndex: next });
-      return next;
-    });
-    return newIndex;
+    const data = doc.data()!;
+    return {
+      type: data['type'] as string,
+      order: data['order'] as string[],
+      currentIndex: data['currentIndex'] as number,
+      deferred: (data['deferred'] as string[] | undefined) ?? [],
+      weeklySlots: data['weeklySlots'] as string[],
+    };
   }
 
   async swapStudents(idA: string, idB: string): Promise<readonly string[]> {
@@ -88,23 +85,116 @@ export class WorkspaceStore {
     return newOrder;
   }
 
-  async skipCurrentStudent(): Promise<{ skippedId: string; newIndex: number }> {
-    const ref = this.db.doc(`workspaces/${this.workspaceId}/rotation/config`);
+  async assignStudentsToEvent(eventId: string): Promise<ClassEvent> {
+    const rotRef = this.db.doc(`workspaces/${this.workspaceId}/rotation/config`);
+    const eventRef = this.col('events').doc(eventId);
+
     return this.db.runTransaction(async (tx) => {
-      const doc = await tx.get(ref);
-      if (!doc.exists) throw new Error('Rotation config not found');
-      const data = doc.data() as RotationConfig;
-      const order = [...data.order];
-      const skippedId = order[data.currentIndex];
-      if (!skippedId) throw new Error('No student at current index');
-      order.splice(data.currentIndex, 1);
-      order.push(skippedId);
-      tx.update(ref, { order, currentIndex: data.currentIndex % order.length });
-      return { skippedId, newIndex: data.currentIndex % order.length };
+      const [rotDoc, eventDoc] = await Promise.all([tx.get(rotRef), tx.get(eventRef)]);
+      if (!rotDoc.exists) throw new Error('Rotation config not found');
+      if (!eventDoc.exists) throw new Error('Event not found');
+
+      const rot = rotDoc.data()!;
+      const event = eventDoc.data()!;
+      const items = (event['items'] as EventItem[]) ?? [];
+
+      if (items.length === 0) throw new Error('Event has no items to assign');
+
+      const order = rot['order'] as string[];
+      const deferred = [...((rot['deferred'] as string[] | undefined) ?? [])];
+      let currentIndex = rot['currentIndex'] as number;
+      const assigned: EventItem[] = [];
+      const usedFromDeferred: string[] = [];
+
+      for (const item of items) {
+        let studentId: string | undefined;
+
+        if (deferred.length > 0) {
+          studentId = deferred.shift()!;
+          usedFromDeferred.push(studentId);
+        } else {
+          studentId = order[currentIndex % order.length];
+          currentIndex = (currentIndex + 1) % order.length;
+        }
+
+        assigned.push({ name: item.name, assignedTo: studentId });
+      }
+
+      tx.update(rotRef, {
+        currentIndex,
+        deferred: deferred.filter((d) => !usedFromDeferred.includes(d)),
+      });
+      tx.update(eventRef, { items: assigned, status: 'assigned' as EventStatus });
+
+      return {
+        id: eventId,
+        date: event['date'] as string,
+        description: event['description'] as string,
+        type: event['type'] as EventType,
+        items: assigned,
+        status: 'assigned' as EventStatus,
+      };
+    });
+  }
+
+  async replaceInEvent(eventId: string, sickStudentId: string): Promise<{ replacementId: string; event: ClassEvent }> {
+    const rotRef = this.db.doc(`workspaces/${this.workspaceId}/rotation/config`);
+    const eventRef = this.col('events').doc(eventId);
+
+    return this.db.runTransaction(async (tx) => {
+      const [rotDoc, eventDoc] = await Promise.all([tx.get(rotRef), tx.get(eventRef)]);
+      if (!rotDoc.exists) throw new Error('Rotation config not found');
+      if (!eventDoc.exists) throw new Error('Event not found');
+
+      const rot = rotDoc.data()!;
+      const event = eventDoc.data()!;
+      const items = [...((event['items'] as EventItem[]) ?? [])];
+
+      const sickItemIndex = items.findIndex((item) => item.assignedTo === sickStudentId);
+      if (sickItemIndex === -1) throw new Error('Student not assigned to this event');
+
+      const order = rot['order'] as string[];
+      const deferred = [...((rot['deferred'] as string[] | undefined) ?? [])];
+      let currentIndex = rot['currentIndex'] as number;
+
+      const replacementId = order[currentIndex % order.length]!;
+      currentIndex = (currentIndex + 1) % order.length;
+
+      items[sickItemIndex] = { name: items[sickItemIndex]!.name, assignedTo: replacementId };
+
+      deferred.push(sickStudentId);
+
+      tx.update(rotRef, { currentIndex, deferred });
+      tx.update(eventRef, { items });
+
+      const updatedEvent: ClassEvent = {
+        id: eventId,
+        date: event['date'] as string,
+        description: event['description'] as string,
+        type: event['type'] as EventType,
+        items,
+        status: event['status'] as EventStatus,
+      };
+
+      return { replacementId, event: updatedEvent };
     });
   }
 
   // --- Events ---
+
+  async getEvent(id: string): Promise<ClassEvent | null> {
+    const doc = await this.col('events').doc(id).get();
+    if (!doc.exists) return null;
+    const data = doc.data()!;
+    return {
+      id: doc.id,
+      date: data['date'] as string,
+      description: data['description'] as string,
+      type: (data['type'] as EventType) ?? 'info',
+      items: (data['items'] as EventItem[]) ?? [],
+      status: (data['status'] as EventStatus) ?? 'draft',
+    };
+  }
 
   async listEventsByDateRange(from: string, to: string): Promise<ClassEvent[]> {
     const snap = await this.col('events')
@@ -112,12 +202,29 @@ export class WorkspaceStore {
       .where('date', '<=', to)
       .orderBy('date')
       .get();
-    return snap.docs.map((d) => ({ id: d.id, ...d.data() }) as ClassEvent);
+    return snap.docs.map((d) => {
+      const data = d.data();
+      return {
+        id: d.id,
+        date: data['date'] as string,
+        description: data['description'] as string,
+        type: (data['type'] as EventType) ?? 'info',
+        items: (data['items'] as EventItem[]) ?? [],
+        status: (data['status'] as EventStatus) ?? 'draft',
+      };
+    });
   }
 
-  async addEvent(event: Omit<ClassEvent, 'id'>): Promise<string> {
-    const ref = await this.col('events').add(event);
+  async addEvent(event: { date: string; description: string; type: EventType; items: EventItem[] }): Promise<string> {
+    const ref = await this.col('events').add({
+      ...event,
+      status: 'draft' as EventStatus,
+    });
     return ref.id;
+  }
+
+  async updateEventStatus(id: string, status: EventStatus): Promise<void> {
+    await this.col('events').doc(id).update({ status });
   }
 
   // --- Drafts ---

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -13,17 +13,25 @@ export interface RotationConfig {
   readonly type: string;
   readonly order: readonly string[];
   readonly currentIndex: number;
+  readonly deferred: readonly string[];
   readonly weeklySlots: readonly string[];
 }
 
-export type EventType = 'snack' | 'material' | 'activity' | 'info';
+export type EventType = 'snack' | 'material' | 'activity' | 'info' | 'birthday';
+export type EventStatus = 'draft' | 'assigned' | 'sent';
+
+export interface EventItem {
+  readonly name: string;
+  readonly assignedTo?: string;
+}
 
 export interface ClassEvent {
   readonly id: string;
   readonly date: string;
   readonly description: string;
-  readonly assignedTo?: string;
   readonly type: EventType;
+  readonly items: readonly EventItem[];
+  readonly status: EventStatus;
 }
 
 export type DraftStatus = 'pending_approval' | 'approved' | 'sent' | 'expired';

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ const app = createRoutes({
   apiKey: env.ANTHROPIC_API_KEY,
   waBucket: env.WA_AUTH_BUCKET,
   defaultWorkspaceId: env.WORKSPACE_ID,
+  adminToken: env.ADMIN_TOKEN,
 });
 
 const port = Number(env.PORT);

--- a/src/web/admin-page.ts
+++ b/src/web/admin-page.ts
@@ -1,0 +1,223 @@
+import type { ClassEvent, RotationConfig, Student, WorkspaceConfig } from '../data/types.js';
+
+interface AdminData {
+  readonly workspaceId: string;
+  readonly config: WorkspaceConfig;
+  readonly students: readonly Student[];
+  readonly rotation: RotationConfig;
+  readonly events: readonly ClassEvent[];
+  readonly token: string;
+}
+
+export function renderAdminPage(data: AdminData): string {
+  const { workspaceId, config, students, rotation, events, token } = data;
+
+  const studentMap = new Map(students.map((s) => [s.id, s.name]));
+
+  const rotationRows = rotation.order.map((id, i) => {
+    const name = studentMap.get(id) ?? id;
+    const isCurrent = i === rotation.currentIndex;
+    return `<li class="rot-item${isCurrent ? ' current' : ''}" data-id="${esc(id)}">
+      <span class="rot-pos">${i + 1}</span>
+      <span class="rot-name">${esc(name)}</span>
+      ${isCurrent ? '<span class="rot-badge">Siguiente</span>' : ''}
+    </li>`;
+  }).join('\n');
+
+  const eventRows = events.length === 0
+    ? '<p class="empty">Sin eventos esta semana</p>'
+    : events.map((e) => `<div class="event-card">
+        <span class="event-date">${esc(e.date)}</span>
+        <span class="event-type tag-${esc(e.type)}">${esc(e.type)}</span>
+        <p>${esc(e.description)}</p>
+      </div>`).join('\n');
+
+  const studentOptions = students
+    .map((s) => `<option value="${esc(s.id)}">${esc(s.name)}</option>`)
+    .join('\n');
+
+  return `<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-title" content="room-bot">
+  <title>room-bot | ${esc(config.className)}</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: #f0f2f5; color: #1a1a1a;
+      padding: 16px; max-width: 600px; margin: 0 auto;
+    }
+    h1 { font-size: 1.3rem; margin-bottom: 4px; }
+    .subtitle { font-size: 0.85rem; color: #666; margin-bottom: 20px; }
+    h2 { font-size: 1.1rem; margin: 24px 0 12px; border-bottom: 2px solid #25d366; padding-bottom: 4px; }
+
+    /* Rotation */
+    .rot-list { list-style: none; }
+    .rot-item {
+      display: flex; align-items: center; gap: 8px;
+      padding: 10px 12px; border-bottom: 1px solid #e0e0e0;
+      font-size: 0.95rem;
+    }
+    .rot-item.current { background: #e8f5e9; border-radius: 8px; border-bottom: none; font-weight: 600; }
+    .rot-pos { color: #999; min-width: 24px; font-size: 0.8rem; }
+    .rot-badge {
+      background: #25d366; color: white; font-size: 0.7rem; font-weight: 700;
+      padding: 2px 8px; border-radius: 12px; margin-left: auto;
+    }
+
+    /* Events */
+    .event-card {
+      background: white; border-radius: 8px; padding: 12px; margin-bottom: 8px;
+      box-shadow: 0 1px 3px rgba(0,0,0,0.08);
+    }
+    .event-date { font-weight: 600; font-size: 0.85rem; margin-right: 8px; }
+    .event-type {
+      font-size: 0.7rem; padding: 2px 8px; border-radius: 12px; font-weight: 600; text-transform: uppercase;
+    }
+    .tag-snack { background: #fff3e0; color: #e65100; }
+    .tag-material { background: #e3f2fd; color: #1565c0; }
+    .tag-activity { background: #f3e5f5; color: #7b1fa2; }
+    .tag-info { background: #e0f2f1; color: #00695c; }
+    .event-card p { margin-top: 6px; font-size: 0.9rem; }
+    .empty { color: #999; font-size: 0.9rem; padding: 12px 0; }
+
+    /* Forms */
+    .form-section {
+      background: white; border-radius: 8px; padding: 16px; margin-top: 12px;
+      box-shadow: 0 1px 3px rgba(0,0,0,0.08);
+    }
+    .form-section h3 { font-size: 0.95rem; margin-bottom: 12px; }
+    label { display: block; font-size: 0.85rem; color: #555; margin-bottom: 4px; margin-top: 10px; }
+    select, input[type="text"], input[type="date"] {
+      width: 100%; padding: 10px; border: 1px solid #ccc; border-radius: 8px;
+      font-size: 0.95rem; font-family: inherit; background: white;
+    }
+    select:focus, input:focus { outline: 2px solid #25d366; border-color: transparent; }
+    .btn {
+      display: inline-block; padding: 10px 20px; border: none; border-radius: 8px;
+      font-size: 0.9rem; font-weight: 600; cursor: pointer; margin-top: 12px;
+    }
+    .btn-primary { background: #25d366; color: white; }
+    .btn-primary:hover { background: #1da851; }
+    .btn-warn { background: #ff9800; color: white; }
+    .btn-warn:hover { background: #e68900; }
+    .btn:disabled { background: #ccc; cursor: not-allowed; }
+    .msg { margin-top: 12px; padding: 10px; border-radius: 8px; font-size: 0.9rem; display: none; }
+    .msg.success { background: #d4edda; color: #155724; display: block; }
+    .msg.error { background: #f8d7da; color: #721c24; display: block; }
+  </style>
+</head>
+<body>
+  <h1>${esc(config.className)}</h1>
+  <p class="subtitle">${esc(config.schoolName)} | ${esc(workspaceId)}</p>
+
+  <h2>Rotacion de snack</h2>
+  <ul class="rot-list">${rotationRows}</ul>
+
+  <div class="form-section">
+    <h3>Saltar turno actual</h3>
+    <p style="font-size:0.85rem;color:#666;margin-bottom:8px;">Mueve al estudiante actual al final de la lista.</p>
+    <button class="btn btn-warn" id="skipBtn" onclick="doSkip()">Saltar turno</button>
+    <div id="skipMsg" class="msg"></div>
+  </div>
+
+  <div class="form-section">
+    <h3>Intercambiar posiciones</h3>
+    <label for="swapA">Estudiante A</label>
+    <select id="swapA">${studentOptions}</select>
+    <label for="swapB">Estudiante B</label>
+    <select id="swapB">${studentOptions}</select>
+    <button class="btn btn-primary" onclick="doSwap()">Intercambiar</button>
+    <div id="swapMsg" class="msg"></div>
+  </div>
+
+  <h2>Eventos proximos</h2>
+  ${eventRows}
+
+  <div class="form-section">
+    <h3>Agregar evento</h3>
+    <label for="evDate">Fecha</label>
+    <input type="date" id="evDate">
+    <label for="evType">Tipo</label>
+    <select id="evType">
+      <option value="snack">Snack</option>
+      <option value="activity">Actividad</option>
+      <option value="material">Material</option>
+      <option value="info">Informacion</option>
+    </select>
+    <label for="evDesc">Descripcion</label>
+    <input type="text" id="evDesc" placeholder="Ej: Sharing snack dieciochero">
+    <button class="btn btn-primary" onclick="doAddEvent()">Agregar</button>
+    <div id="eventMsg" class="msg"></div>
+  </div>
+
+  <script>
+    const W = '${esc(workspaceId)}';
+    const T = '${esc(token)}';
+
+    async function api(path, body) {
+      const res = await fetch(path + '?token=' + T, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ...body, workspaceId: W }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || 'Error');
+      return data;
+    }
+
+    function showMsg(id, ok, text) {
+      const el = document.getElementById(id);
+      el.className = 'msg ' + (ok ? 'success' : 'error');
+      el.textContent = text;
+      el.style.display = 'block';
+    }
+
+    async function doSkip() {
+      const btn = document.getElementById('skipBtn');
+      btn.disabled = true;
+      try {
+        const data = await api('/rotation/skip', {});
+        showMsg('skipMsg', true, 'Turno saltado. Recarga para ver el cambio.');
+      } catch (err) { showMsg('skipMsg', false, err.message); }
+      btn.disabled = false;
+    }
+
+    async function doSwap() {
+      const a = document.getElementById('swapA').value;
+      const b = document.getElementById('swapB').value;
+      if (a === b) { showMsg('swapMsg', false, 'Selecciona dos estudiantes diferentes'); return; }
+      try {
+        await api('/rotation/swap', { studentA: a, studentB: b });
+        showMsg('swapMsg', true, 'Posiciones intercambiadas. Recarga para ver el cambio.');
+      } catch (err) { showMsg('swapMsg', false, err.message); }
+    }
+
+    async function doAddEvent() {
+      const date = document.getElementById('evDate').value;
+      const type = document.getElementById('evType').value;
+      const description = document.getElementById('evDesc').value;
+      if (!date || !description) { showMsg('eventMsg', false, 'Completa fecha y descripcion'); return; }
+      try {
+        await api('/admin/${esc(workspaceId)}/event', { date, type, description });
+        showMsg('eventMsg', true, 'Evento agregado. Recarga para verlo.');
+        document.getElementById('evDesc').value = '';
+      } catch (err) { showMsg('eventMsg', false, err.message); }
+    }
+  </script>
+</body>
+</html>`;
+}
+
+function esc(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}

--- a/src/web/admin-page.ts
+++ b/src/web/admin-page.ts
@@ -14,23 +14,74 @@ export function renderAdminPage(data: AdminData): string {
 
   const studentMap = new Map(students.map((s) => [s.id, s.name]));
 
+  const eventCards = events.length === 0
+    ? '<p class="empty">Sin eventos esta semana</p>'
+    : events.map((e) => {
+        const statusBadge = e.status === 'assigned'
+          ? '<span class="status-badge assigned">Asignado</span>'
+          : e.status === 'sent'
+            ? '<span class="status-badge sent">Enviado</span>'
+            : '<span class="status-badge draft">Borrador</span>';
+
+        const itemRows = e.items.length === 0
+          ? '<p class="empty">Sin items</p>'
+          : e.items.map((item) => {
+              const assignedName = item.assignedTo
+                ? (studentMap.get(item.assignedTo) ?? item.assignedTo)
+                : 'Sin asignar';
+              const replaceBtn = item.assignedTo && e.status === 'assigned'
+                ? `<button class="btn-replace" onclick="doReplace('${esc(e.id)}','${esc(item.assignedTo)}')">Reemplazar</button>`
+                : '';
+              return `<li class="item-row">
+                <span class="item-name">${esc(item.name)}</span>
+                <span class="item-assigned ${item.assignedTo ? 'has-student' : ''}">${esc(assignedName)}</span>
+                ${replaceBtn}
+              </li>`;
+            }).join('\n');
+
+        const assignBtn = e.status === 'draft' && e.items.length > 0
+          ? `<button class="btn btn-primary" onclick="doAssign('${esc(e.id)}')">Asignar estudiantes</button>`
+          : '';
+
+        return `<div class="event-card" id="event-${esc(e.id)}">
+          <div class="event-header">
+            <span class="event-date">${esc(e.date)}</span>
+            <span class="event-type tag-${esc(e.type)}">${esc(e.type)}</span>
+            ${statusBadge}
+          </div>
+          <p class="event-desc">${esc(e.description)}</p>
+          <ul class="item-list">${itemRows}</ul>
+          ${assignBtn}
+          <div id="msg-${esc(e.id)}" class="msg"></div>
+        </div>`;
+      }).join('\n');
+
+  const deferredSection = rotation.deferred.length === 0
+    ? ''
+    : `<div class="deferred-section">
+        <h3>Estudiantes diferidos (prioridad en proximo evento)</h3>
+        <ul class="deferred-list">
+          ${rotation.deferred.map((id) => {
+            const name = studentMap.get(id) ?? id;
+            return `<li class="deferred-item">${esc(name)}</li>`;
+          }).join('\n')}
+        </ul>
+      </div>`;
+
   const rotationRows = rotation.order.map((id, i) => {
     const name = studentMap.get(id) ?? id;
     const isCurrent = i === rotation.currentIndex;
-    return `<li class="rot-item${isCurrent ? ' current' : ''}" data-id="${esc(id)}">
+    const isDeferred = rotation.deferred.includes(id);
+    let cls = '';
+    if (isCurrent) cls = ' current';
+    if (isDeferred) cls += ' deferred';
+    return `<li class="rot-item${cls}">
       <span class="rot-pos">${i + 1}</span>
       <span class="rot-name">${esc(name)}</span>
       ${isCurrent ? '<span class="rot-badge">Siguiente</span>' : ''}
+      ${isDeferred ? '<span class="rot-badge deferred">Diferido</span>' : ''}
     </li>`;
   }).join('\n');
-
-  const eventRows = events.length === 0
-    ? '<p class="empty">Sin eventos esta semana</p>'
-    : events.map((e) => `<div class="event-card">
-        <span class="event-date">${esc(e.date)}</span>
-        <span class="event-type tag-${esc(e.type)}">${esc(e.type)}</span>
-        <p>${esc(e.description)}</p>
-      </div>`).join('\n');
 
   const studentOptions = students
     .map((s) => `<option value="${esc(s.id)}">${esc(s.name)}</option>`)
@@ -54,27 +105,15 @@ export function renderAdminPage(data: AdminData): string {
     h1 { font-size: 1.3rem; margin-bottom: 4px; }
     .subtitle { font-size: 0.85rem; color: #666; margin-bottom: 20px; }
     h2 { font-size: 1.1rem; margin: 24px 0 12px; border-bottom: 2px solid #25d366; padding-bottom: 4px; }
-
-    /* Rotation */
-    .rot-list { list-style: none; }
-    .rot-item {
-      display: flex; align-items: center; gap: 8px;
-      padding: 10px 12px; border-bottom: 1px solid #e0e0e0;
-      font-size: 0.95rem;
-    }
-    .rot-item.current { background: #e8f5e9; border-radius: 8px; border-bottom: none; font-weight: 600; }
-    .rot-pos { color: #999; min-width: 24px; font-size: 0.8rem; }
-    .rot-badge {
-      background: #25d366; color: white; font-size: 0.7rem; font-weight: 700;
-      padding: 2px 8px; border-radius: 12px; margin-left: auto;
-    }
+    h3 { font-size: 1rem; margin-bottom: 8px; }
 
     /* Events */
     .event-card {
-      background: white; border-radius: 8px; padding: 12px; margin-bottom: 8px;
+      background: white; border-radius: 8px; padding: 12px; margin-bottom: 12px;
       box-shadow: 0 1px 3px rgba(0,0,0,0.08);
     }
-    .event-date { font-weight: 600; font-size: 0.85rem; margin-right: 8px; }
+    .event-header { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+    .event-date { font-weight: 600; font-size: 0.85rem; }
     .event-type {
       font-size: 0.7rem; padding: 2px 8px; border-radius: 12px; font-weight: 600; text-transform: uppercase;
     }
@@ -82,8 +121,56 @@ export function renderAdminPage(data: AdminData): string {
     .tag-material { background: #e3f2fd; color: #1565c0; }
     .tag-activity { background: #f3e5f5; color: #7b1fa2; }
     .tag-info { background: #e0f2f1; color: #00695c; }
-    .event-card p { margin-top: 6px; font-size: 0.9rem; }
-    .empty { color: #999; font-size: 0.9rem; padding: 12px 0; }
+    .tag-birthday { background: #fce4ec; color: #c62828; }
+    .status-badge {
+      font-size: 0.65rem; padding: 2px 8px; border-radius: 10px; font-weight: 700;
+      margin-left: auto;
+    }
+    .status-badge.draft { background: #e0e0e0; color: #616161; }
+    .status-badge.assigned { background: #c8e6c9; color: #2e7d32; }
+    .status-badge.sent { background: #bbdefb; color: #1565c0; }
+    .event-desc { margin-top: 8px; font-size: 0.9rem; }
+
+    /* Items */
+    .item-list { list-style: none; margin-top: 8px; }
+    .item-row {
+      display: flex; align-items: center; gap: 8px;
+      padding: 8px 12px; border-bottom: 1px solid #f0f0f0;
+      font-size: 0.85rem;
+    }
+    .item-name { font-weight: 600; min-width: 80px; }
+    .item-assigned { flex: 1; color: #999; }
+    .item-assigned.has-student { color: #1a1a1a; }
+    .btn-replace {
+      background: #f44336; color: white; border: none; border-radius: 6px;
+      padding: 4px 10px; font-size: 0.7rem; font-weight: 600; cursor: pointer;
+    }
+    .btn-replace:hover { background: #d32f2f; }
+
+    /* Deferred */
+    .deferred-section {
+      background: #fff8e1; border-radius: 8px; padding: 12px; margin-bottom: 12px;
+      border-left: 4px solid #ff9800;
+    }
+    .deferred-section h3 { font-size: 0.85rem; color: #e65100; margin-bottom: 8px; }
+    .deferred-list { list-style: none; }
+    .deferred-item { padding: 4px 0; font-size: 0.85rem; }
+
+    /* Rotation */
+    .rot-list { list-style: none; }
+    .rot-item {
+      display: flex; align-items: center; gap: 8px;
+      padding: 8px 12px; border-bottom: 1px solid #e0e0e0;
+      font-size: 0.85rem;
+    }
+    .rot-item.current { background: #e8f5e9; font-weight: 600; }
+    .rot-item.deferred { background: #fff8e1; }
+    .rot-pos { color: #999; min-width: 24px; font-size: 0.8rem; }
+    .rot-badge {
+      background: #25d366; color: white; font-size: 0.65rem; font-weight: 700;
+      padding: 2px 6px; border-radius: 10px; margin-left: auto;
+    }
+    .rot-badge.deferred { background: #ff9800; }
 
     /* Forms */
     .form-section {
@@ -92,7 +179,7 @@ export function renderAdminPage(data: AdminData): string {
     }
     .form-section h3 { font-size: 0.95rem; margin-bottom: 12px; }
     label { display: block; font-size: 0.85rem; color: #555; margin-bottom: 4px; margin-top: 10px; }
-    select, input[type="text"], input[type="date"] {
+    select, input[type="text"], input[type="date"], input[type="number"] {
       width: 100%; padding: 10px; border: 1px solid #ccc; border-radius: 8px;
       font-size: 0.95rem; font-family: inherit; background: white;
     }
@@ -103,40 +190,31 @@ export function renderAdminPage(data: AdminData): string {
     }
     .btn-primary { background: #25d366; color: white; }
     .btn-primary:hover { background: #1da851; }
-    .btn-warn { background: #ff9800; color: white; }
-    .btn-warn:hover { background: #e68900; }
     .btn:disabled { background: #ccc; cursor: not-allowed; }
-    .msg { margin-top: 12px; padding: 10px; border-radius: 8px; font-size: 0.9rem; display: none; }
+    .msg { margin-top: 8px; padding: 10px; border-radius: 8px; font-size: 0.9rem; display: none; }
     .msg.success { background: #d4edda; color: #155724; display: block; }
     .msg.error { background: #f8d7da; color: #721c24; display: block; }
+    .empty { color: #999; font-size: 0.9rem; padding: 12px 0; }
+    .items-builder { margin-top: 8px; }
+    .items-builder .item-input {
+      display: flex; gap: 8px; margin-bottom: 6px;
+    }
+    .items-builder input { flex: 1; }
+    .btn-sm {
+      padding: 6px 12px; font-size: 0.8rem; border: none; border-radius: 6px;
+      cursor: pointer; font-weight: 600;
+    }
+    .btn-add-item { background: #e0e0e0; color: #333; }
+    .btn-remove-item { background: #ffcdd2; color: #c62828; min-width: 32px; }
   </style>
 </head>
 <body>
   <h1>${esc(config.className)}</h1>
   <p class="subtitle">${esc(config.schoolName)} | ${esc(workspaceId)}</p>
 
-  <h2>Rotacion de snack</h2>
-  <ul class="rot-list">${rotationRows}</ul>
-
-  <div class="form-section">
-    <h3>Saltar turno actual</h3>
-    <p style="font-size:0.85rem;color:#666;margin-bottom:8px;">Mueve al estudiante actual al final de la lista.</p>
-    <button class="btn btn-warn" id="skipBtn" onclick="doSkip()">Saltar turno</button>
-    <div id="skipMsg" class="msg"></div>
-  </div>
-
-  <div class="form-section">
-    <h3>Intercambiar posiciones</h3>
-    <label for="swapA">Estudiante A</label>
-    <select id="swapA">${studentOptions}</select>
-    <label for="swapB">Estudiante B</label>
-    <select id="swapB">${studentOptions}</select>
-    <button class="btn btn-primary" onclick="doSwap()">Intercambiar</button>
-    <div id="swapMsg" class="msg"></div>
-  </div>
-
   <h2>Eventos proximos</h2>
-  ${eventRows}
+  ${deferredSection}
+  ${eventCards}
 
   <div class="form-section">
     <h3>Agregar evento</h3>
@@ -148,11 +226,35 @@ export function renderAdminPage(data: AdminData): string {
       <option value="activity">Actividad</option>
       <option value="material">Material</option>
       <option value="info">Informacion</option>
+      <option value="birthday">Cumpleanos</option>
     </select>
     <label for="evDesc">Descripcion</label>
     <input type="text" id="evDesc" placeholder="Ej: Sharing snack dieciochero">
-    <button class="btn btn-primary" onclick="doAddEvent()">Agregar</button>
+    <label>Items (cada item se asigna a un estudiante)</label>
+    <div id="itemsBuilder" class="items-builder">
+      <div class="item-input">
+        <input type="text" placeholder="Ej: Jugo, Galletas, Fruta..." class="item-field">
+        <button class="btn-sm btn-remove-item" onclick="removeItem(this)">X</button>
+      </div>
+    </div>
+    <button class="btn-sm btn-add-item" onclick="addItem()" style="margin-top:4px">+ Agregar item</button>
+    <br>
+    <button class="btn btn-primary" onclick="doAddEvent()">Crear evento</button>
     <div id="eventMsg" class="msg"></div>
+  </div>
+
+  <h2>Rotacion</h2>
+  <p style="font-size:0.85rem;color:#666;margin-bottom:8px">Posicion actual: ${rotation.currentIndex + 1} de ${rotation.order.length}</p>
+  <ul class="rot-list">${rotationRows}</ul>
+
+  <div class="form-section">
+    <h3>Intercambiar posiciones</h3>
+    <label for="swapA">Estudiante A</label>
+    <select id="swapA">${studentOptions}</select>
+    <label for="swapB">Estudiante B</label>
+    <select id="swapB">${studentOptions}</select>
+    <button class="btn btn-primary" onclick="doSwap()">Intercambiar</button>
+    <div id="swapMsg" class="msg"></div>
   </div>
 
   <script>
@@ -163,7 +265,7 @@ export function renderAdminPage(data: AdminData): string {
       const res = await fetch(path + '?token=' + T, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ ...body, workspaceId: W }),
+        body: JSON.stringify(body),
       });
       const data = await res.json();
       if (!res.ok) throw new Error(data.error || 'Error');
@@ -172,19 +274,28 @@ export function renderAdminPage(data: AdminData): string {
 
     function showMsg(id, ok, text) {
       const el = document.getElementById(id);
+      if (!el) return;
       el.className = 'msg ' + (ok ? 'success' : 'error');
       el.textContent = text;
       el.style.display = 'block';
     }
 
-    async function doSkip() {
-      const btn = document.getElementById('skipBtn');
-      btn.disabled = true;
+    async function doAssign(eventId) {
+      if (!confirm('Asignar estudiantes a este evento?')) return;
       try {
-        const data = await api('/rotation/skip', {});
-        showMsg('skipMsg', true, 'Turno saltado. Recarga para ver el cambio.');
-      } catch (err) { showMsg('skipMsg', false, err.message); }
-      btn.disabled = false;
+        await api('/admin/' + W + '/event/' + eventId + '/assign', {});
+        showMsg('msg-' + eventId, true, 'Estudiantes asignados. Recargando...');
+        setTimeout(() => location.reload(), 1500);
+      } catch (err) { showMsg('msg-' + eventId, false, err.message); }
+    }
+
+    async function doReplace(eventId, studentId) {
+      if (!confirm('Reemplazar este estudiante? El estudiante enfermo pasa al proximo evento.')) return;
+      try {
+        await api('/admin/' + W + '/event/' + eventId + '/replace', { studentId });
+        showMsg('msg-' + eventId, true, 'Estudiante reemplazado. Recargando...');
+        setTimeout(() => location.reload(), 1500);
+      } catch (err) { showMsg('msg-' + eventId, false, err.message); }
     }
 
     async function doSwap() {
@@ -192,9 +303,25 @@ export function renderAdminPage(data: AdminData): string {
       const b = document.getElementById('swapB').value;
       if (a === b) { showMsg('swapMsg', false, 'Selecciona dos estudiantes diferentes'); return; }
       try {
-        await api('/rotation/swap', { studentA: a, studentB: b });
-        showMsg('swapMsg', true, 'Posiciones intercambiadas. Recarga para ver el cambio.');
+        await api('/rotation/swap', { studentA: a, studentB: b, workspaceId: W });
+        showMsg('swapMsg', true, 'Posiciones intercambiadas. Recargando...');
+        setTimeout(() => location.reload(), 1500);
       } catch (err) { showMsg('swapMsg', false, err.message); }
+    }
+
+    function addItem() {
+      const div = document.createElement('div');
+      div.className = 'item-input';
+      div.innerHTML = '<input type="text" placeholder="Ej: Jugo, Galletas, Fruta..." class="item-field">'
+        + '<button class="btn-sm btn-remove-item" onclick="removeItem(this)">X</button>';
+      document.getElementById('itemsBuilder').appendChild(div);
+    }
+
+    function removeItem(btn) {
+      const container = document.getElementById('itemsBuilder');
+      if (container.children.length > 1) {
+        btn.parentElement.remove();
+      }
     }
 
     async function doAddEvent() {
@@ -202,10 +329,18 @@ export function renderAdminPage(data: AdminData): string {
       const type = document.getElementById('evType').value;
       const description = document.getElementById('evDesc').value;
       if (!date || !description) { showMsg('eventMsg', false, 'Completa fecha y descripcion'); return; }
+
+      const itemFields = document.querySelectorAll('.item-field');
+      const items = [];
+      itemFields.forEach(function(f) {
+        const val = f.value.trim();
+        if (val) items.push({ name: val });
+      });
+
       try {
-        await api('/admin/${esc(workspaceId)}/event', { date, type, description });
-        showMsg('eventMsg', true, 'Evento agregado. Recarga para verlo.');
-        document.getElementById('evDesc').value = '';
+        await api('/admin/' + W + '/event', { date, type, description, items });
+        showMsg('eventMsg', true, 'Evento creado. Recargando...');
+        setTimeout(() => location.reload(), 1500);
       } catch (err) { showMsg('eventMsg', false, err.message); }
     }
   </script>

--- a/src/web/routes.ts
+++ b/src/web/routes.ts
@@ -1,6 +1,7 @@
 import { Firestore } from '@google-cloud/firestore';
 import { Hono } from 'hono';
 import { WorkspaceStore } from '../data/firestore.js';
+import type { EventItem } from '../data/types.js';
 import { runDailyReminder } from '../reminders/daily.js';
 import { runWeeklyReminder } from '../reminders/weekly.js';
 import { GcsAuthStore } from '../whatsapp/auth-store.js';
@@ -170,21 +171,6 @@ export function createRoutes(env: AppEnv): Hono {
     }
   });
 
-  app.post('/rotation/skip', async (c) => {
-    const body = await c.req.json().catch(() => ({})) as { workspaceId?: string };
-    const workspaceId = (body as Record<string, unknown>)['workspaceId'] as string | undefined
-      ?? env.defaultWorkspaceId;
-
-    const store = new WorkspaceStore(env.db, workspaceId);
-    try {
-      const result = await store.skipCurrentStudent();
-      log.info(result, 'rotation.skipped');
-      return c.json({ status: 'skipped', ...result });
-    } catch (err) {
-      log.error({ err: String(err) }, 'rotation.skip.failed');
-      return c.json({ error: String(err) }, 400);
-    }
-  });
 
   // --- Admin dashboard ---
 
@@ -229,6 +215,7 @@ export function createRoutes(env: AppEnv): Hono {
       date?: string;
       type?: string;
       description?: string;
+      items?: EventItem[];
     };
 
     if (!body.date || !body.description) {
@@ -241,12 +228,58 @@ export function createRoutes(env: AppEnv): Hono {
         date: body.date,
         type: (body.type ?? 'info') as 'snack' | 'material' | 'activity' | 'info',
         description: body.description,
+        items: body.items ?? [],
       });
       log.info({ eventId, workspaceId }, 'admin.event.added');
       return c.json({ status: 'added', eventId });
     } catch (err) {
       log.error({ err: String(err) }, 'admin.event.add.failed');
       return c.json({ error: String(err) }, 500);
+    }
+  });
+
+  app.post('/admin/:workspaceId/event/:eventId/assign', async (c) => {
+    const token = c.req.query('token') ?? '';
+    if (token !== env.adminToken) {
+      return c.json({ error: 'No autorizado' }, 401);
+    }
+
+    const workspaceId = c.req.param('workspaceId');
+    const eventId = c.req.param('eventId');
+    const store = new WorkspaceStore(env.db, workspaceId);
+
+    try {
+      const event = await store.assignStudentsToEvent(eventId);
+      log.info({ eventId, workspaceId, items: event.items.length }, 'admin.event.assigned');
+      return c.json({ status: 'assigned', event });
+    } catch (err) {
+      log.error({ err: String(err), eventId }, 'admin.event.assign.failed');
+      return c.json({ error: String(err) }, 400);
+    }
+  });
+
+  app.post('/admin/:workspaceId/event/:eventId/replace', async (c) => {
+    const token = c.req.query('token') ?? '';
+    if (token !== env.adminToken) {
+      return c.json({ error: 'No autorizado' }, 401);
+    }
+
+    const workspaceId = c.req.param('workspaceId');
+    const eventId = c.req.param('eventId');
+    const body = await c.req.json() as { studentId?: string };
+
+    if (!body.studentId) {
+      return c.json({ error: 'studentId is required' }, 400);
+    }
+
+    const store = new WorkspaceStore(env.db, workspaceId);
+    try {
+      const result = await store.replaceInEvent(eventId, body.studentId);
+      log.info({ eventId, studentId: body.studentId, replacementId: result.replacementId }, 'admin.event.replaced');
+      return c.json({ status: 'replaced', replacementId: result.replacementId, event: result.event });
+    } catch (err) {
+      log.error({ err: String(err), eventId }, 'admin.event.replace.failed');
+      return c.json({ error: String(err) }, 400);
     }
   });
 

--- a/src/web/routes.ts
+++ b/src/web/routes.ts
@@ -6,6 +6,7 @@ import { runWeeklyReminder } from '../reminders/weekly.js';
 import { GcsAuthStore } from '../whatsapp/auth-store.js';
 import { WhatsAppClient } from '../whatsapp/client.js';
 import { childLogger } from '../utils/logger.js';
+import { renderAdminPage } from './admin-page.js';
 import { renderApprovePage } from './approve-page.js';
 
 const log = childLogger('routes');
@@ -15,6 +16,7 @@ interface AppEnv {
   readonly apiKey: string;
   readonly waBucket: string;
   readonly defaultWorkspaceId: string;
+  readonly adminToken: string;
 }
 
 export function createRoutes(env: AppEnv): Hono {
@@ -181,6 +183,70 @@ export function createRoutes(env: AppEnv): Hono {
     } catch (err) {
       log.error({ err: String(err) }, 'rotation.skip.failed');
       return c.json({ error: String(err) }, 400);
+    }
+  });
+
+  // --- Admin dashboard ---
+
+  app.get('/admin/:workspaceId', async (c) => {
+    const token = c.req.query('token') ?? '';
+    if (token !== env.adminToken) {
+      return c.text('No autorizado', 401);
+    }
+
+    const workspaceId = c.req.param('workspaceId');
+    const store = new WorkspaceStore(env.db, workspaceId);
+
+    try {
+      const today = new Date();
+      const nextWeek = new Date(today);
+      nextWeek.setDate(today.getDate() + 7);
+      const fromDate = today.toISOString().slice(0, 10);
+      const toDate = nextWeek.toISOString().slice(0, 10);
+
+      const [config, students, rotation, events] = await Promise.all([
+        store.getConfig(),
+        store.listStudents(),
+        store.getRotation(),
+        store.listEventsByDateRange(fromDate, toDate),
+      ]);
+
+      return c.html(renderAdminPage({ workspaceId, config, students, rotation, events, token }));
+    } catch (err) {
+      log.error({ err: String(err), workspaceId }, 'admin.load.failed');
+      return c.text('Error cargando datos: ' + String(err), 500);
+    }
+  });
+
+  app.post('/admin/:workspaceId/event', async (c) => {
+    const token = c.req.query('token') ?? '';
+    if (token !== env.adminToken) {
+      return c.json({ error: 'No autorizado' }, 401);
+    }
+
+    const workspaceId = c.req.param('workspaceId');
+    const body = await c.req.json() as {
+      date?: string;
+      type?: string;
+      description?: string;
+    };
+
+    if (!body.date || !body.description) {
+      return c.json({ error: 'date and description are required' }, 400);
+    }
+
+    const store = new WorkspaceStore(env.db, workspaceId);
+    try {
+      const eventId = await store.addEvent({
+        date: body.date,
+        type: (body.type ?? 'info') as 'snack' | 'material' | 'activity' | 'info',
+        description: body.description,
+      });
+      log.info({ eventId, workspaceId }, 'admin.event.added');
+      return c.json({ status: 'added', eventId });
+    } catch (err) {
+      log.error({ err: String(err) }, 'admin.event.add.failed');
+      return c.json({ error: String(err) }, 500);
     }
   });
 


### PR DESCRIPTION
## Summary
- Admin dashboard accessible from mobile (Cloud Run, token-based auth)
- Event-driven rotation model: events define items, each item assigned to one student
- Sick student replacement: deferred to next event, replacement from rotation
- Removed fixed groupSize logic in favor of dynamic per-event assignment

## Changes
- `types.ts`: EventItem, ClassEvent, EventStatus types; removed groupSize from RotationConfig
- `firestore.ts`: assignStudentsToEvent(), replaceInEvent() with Firestore transactions
- `routes.ts`: event assign/replace endpoints, removed old groupSize routes
- `admin-page.ts`: event-centric UI with items builder, assign/replace buttons
- `message-generator.ts`: updated prompt to iterate event items
- `seed-students.ts`: seeds deferred:[] instead of groupSize

## Test plan
- [ ] Deploy to Cloud Run
- [ ] Access admin at /admin/pgma?token=TOKEN
- [ ] Create event with items via the form
- [ ] Assign students to event
- [ ] Replace a student (sick flow)
- [ ] Verify rotation pointer advances correctly
- [ ] Verify deferred student gets priority in next assignment