### PR TITLE
feat: add Gmail scanner for school emails in weekly reminder

### DIFF
--- a/infra/deploy.sh
+++ b/infra/deploy.sh
@@ -21,7 +21,7 @@ gcloud run deploy "${SERVICE_NAME}" \
   --source=. \
   --service-account="${SA_EMAIL}" \
   --set-env-vars="GCP_PROJECT_ID=${PROJECT_ID},WA_AUTH_BUCKET=${BUCKET_NAME},WORKSPACE_ID=pgma,ADMIN_TOKEN=${ADMIN_TOKEN:?Set ADMIN_TOKEN env var before deploying}" \
-  --set-secrets="ANTHROPIC_API_KEY=anthropic-api-key:latest" \
+  --set-secrets="ANTHROPIC_API_KEY=anthropic-api-key:latest,GMAIL_CLIENT_ID=gmail-client-id:latest,GMAIL_CLIENT_SECRET=gmail-client-secret:latest,GMAIL_REFRESH_TOKEN=gmail-refresh-token:latest" \
   --timeout=120 \
   --memory=512Mi \
   --cpu=1 \

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@whiskeysockets/baileys": "7.0.0-rc.9",
         "date-fns": "^4.1.0",
         "date-fns-tz": "^3.2.0",
+        "googleapis": "^144.0.0",
         "hono": "^4.7.0",
         "pino": "^9.6.0",
         "qrcode-terminal": "^0.12.0",
@@ -2122,6 +2123,22 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/chai": {
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
@@ -2773,6 +2790,49 @@
         "node": ">=14"
       }
     },
+    "node_modules/googleapis": {
+      "version": "144.0.0",
+      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-144.0.0.tgz",
+      "integrity": "sha512-ELcWOXtJxjPX4vsKMh+7V+jZvgPwYMlEhQFiu2sa9Qmt5veX8nwXPksOWGGN6Zk4xCiLygUyaz7xGtcMO+Onxw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^9.0.0",
+        "googleapis-common": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/googleapis-common": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-7.2.0.tgz",
+      "integrity": "sha512-/fhDZEJZvOV3X5jmD+fKxMqma5q2Q9nZNSF3kn1F18tpxmA86BcTxAGBQdM0N89Z3bEaIs+HVznSmFJEAmMTjA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "gaxios": "^6.0.3",
+        "google-auth-library": "^9.7.0",
+        "qs": "^6.7.0",
+        "url-template": "^2.0.8",
+        "uuid": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/googleapis-common/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -3263,6 +3323,18 @@
         "node": ">= 6"
       }
     },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/on-exit-leak-free": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
@@ -3514,6 +3586,21 @@
         "qrcode-terminal": "bin/qrcode-terminal.js"
       }
     },
+    "node_modules/qs": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/quick-format-unescaped": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
@@ -3715,6 +3802,78 @@
         "@img/sharp-win32-arm64": "0.34.5",
         "@img/sharp-win32-ia32": "0.34.5",
         "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/siginfo": {
@@ -4068,6 +4227,12 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "license": "MIT"
+    },
+    "node_modules/url-template": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+      "integrity": "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==",
+      "license": "BSD"
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -14,10 +14,12 @@
     "wa-login": "tsx --env-file=.env.local scripts/wa-login.ts",
     "seed-students": "tsx --env-file=.env.local scripts/seed-students.ts",
     "seed-voice": "tsx --env-file=.env.local scripts/seed-voice.ts",
-    "send-test": "tsx --env-file=.env.local scripts/send-test.ts"
+    "send-test": "tsx --env-file=.env.local scripts/send-test.ts",
+    "gmail-auth": "tsx --env-file=.env.local scripts/gmail-auth.ts"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.39.0",
+    "googleapis": "^144.0.0",
     "@google-cloud/firestore": "^7.11.0",
     "@google-cloud/storage": "^7.15.0",
     "@hono/node-server": "^1.13.8",

--- a/scripts/gmail-auth.ts
+++ b/scripts/gmail-auth.ts
@@ -1,0 +1,82 @@
+// One-time script to obtain a Gmail OAuth2 refresh token.
+// Run: npm run gmail-auth
+// After running, follow the printed instructions to store the token.
+
+import { google } from 'googleapis';
+import * as http from 'node:http';
+import { URL } from 'node:url';
+
+const SCOPES = ['https://www.googleapis.com/auth/gmail.readonly'];
+const PORT = 3003;
+const REDIRECT_URI = `http://localhost:${PORT}`;
+
+async function main(): Promise<void> {
+  const clientId = process.env['GOOGLE_CLIENT_ID'];
+  const clientSecret = process.env['GOOGLE_CLIENT_SECRET'];
+
+  if (!clientId || !clientSecret) {
+    console.error('Missing GOOGLE_CLIENT_ID or GOOGLE_CLIENT_SECRET in .env.local');
+    process.exit(1);
+  }
+
+  const oauth2Client = new google.auth.OAuth2(clientId, clientSecret, REDIRECT_URI);
+
+  const authUrl = oauth2Client.generateAuthUrl({
+    access_type: 'offline',
+    scope: SCOPES,
+    prompt: 'consent', // force refresh_token to be returned
+  });
+
+  console.log('\nOpen this URL in your browser:\n');
+  console.log(authUrl);
+  console.log('\nWaiting for authorization on http://localhost:3003 ...\n');
+
+  const code = await waitForCode(PORT);
+  const { tokens } = await oauth2Client.getToken(code);
+
+  if (!tokens.refresh_token) {
+    console.error('\nNo refresh_token in response.');
+    console.error('Revoke existing access at https://myaccount.google.com/permissions and run again.');
+    process.exit(1);
+  }
+
+  const refreshToken = tokens.refresh_token;
+
+  console.log('\n=== Autorizado ===\n');
+  console.log('1. Agrega a .env.local:');
+  console.log(`   GMAIL_REFRESH_TOKEN=${refreshToken}\n`);
+  console.log('2. Guarda en Secret Manager:');
+  console.log(`   echo -n "${refreshToken}" | gcloud secrets create gmail-refresh-token --data-file=- --project=recole-485714`);
+  console.log(`   echo -n "${clientId}" | gcloud secrets create gmail-client-id --data-file=- --project=recole-485714`);
+  console.log(`   echo -n "${clientSecret}" | gcloud secrets create gmail-client-secret --data-file=- --project=recole-485714\n`);
+}
+
+function waitForCode(port: number): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const server = http.createServer((req, res) => {
+      if (!req.url) return;
+      const url = new URL(req.url, `http://localhost:${port}`);
+      const code = url.searchParams.get('code');
+      const error = url.searchParams.get('error');
+
+      res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+      if (code) {
+        res.end('<h2>Autorizado. Puedes cerrar esta ventana.</h2>');
+        server.close();
+        resolve(code);
+      } else {
+        res.end(`<h2>Error: ${error ?? 'desconocido'}</h2>`);
+        server.close();
+        reject(new Error(error ?? 'OAuth error'));
+      }
+    });
+
+    server.listen(port, () => {});
+    server.on('error', reject);
+  });
+}
+
+main().catch((err: unknown) => {
+  console.error('Auth failed:', err);
+  process.exit(1);
+});

--- a/src/ai/message-generator.ts
+++ b/src/ai/message-generator.ts
@@ -1,4 +1,5 @@
 import type { ClassEvent, RotationConfig, Student, VoiceExample } from '../data/types.js';
+import type { SchoolEmail } from '../gmail/scanner.js';
 import { generateMessage } from './client.js';
 
 export interface ReminderContext {
@@ -9,6 +10,7 @@ export interface ReminderContext {
   readonly voiceExamples: readonly VoiceExample[];
   readonly className: string;
   readonly schoolName: string;
+  readonly schoolEmails?: readonly SchoolEmail[];
 }
 
 export async function generateReminder(
@@ -56,6 +58,13 @@ function buildUserPrompt(ctx: ReminderContext): string {
 
   lines.push('', `Clase: ${ctx.className}, ${ctx.schoolName}`);
 
+  if (ctx.schoolEmails && ctx.schoolEmails.length > 0) {
+    lines.push('', 'Informativos del colegio (esta semana):');
+    for (const email of ctx.schoolEmails) {
+      lines.push('', `--- ${email.date} | ${email.subject} ---`, email.body);
+    }
+  }
+
   if (ctx.events.length > 0) {
     lines.push('', 'Eventos:');
     for (const ev of ctx.events) {
@@ -77,7 +86,11 @@ function buildUserPrompt(ctx: ReminderContext): string {
     }
   }
 
-  if (ctx.events.length === 0 && snackStudents.length === 0) {
+  const hasContent = ctx.events.length > 0
+    || snackStudents.length > 0
+    || (ctx.schoolEmails && ctx.schoolEmails.length > 0);
+
+  if (!hasContent) {
     lines.push('', 'No hay eventos ni colaciones programadas.');
   }
 

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -52,6 +52,9 @@ export const EnvSchema = z.object({
   WORKSPACE_ID: z.string().min(1),
   ADMIN_TOKEN: z.string().min(1),
   PORT: z.string().default('8080'),
+  GMAIL_CLIENT_ID: z.string().optional(),
+  GMAIL_CLIENT_SECRET: z.string().optional(),
+  GMAIL_REFRESH_TOKEN: z.string().optional(),
 });
 
 export type Env = z.infer<typeof EnvSchema>;

--- a/src/gmail/scanner.ts
+++ b/src/gmail/scanner.ts
@@ -1,0 +1,104 @@
+import { google } from 'googleapis';
+import type { gmail_v1 } from 'googleapis';
+
+export interface SchoolEmail {
+  readonly subject: string;
+  readonly date: string; // YYYY-MM-DD
+  readonly body: string;
+}
+
+const SENDER = 'no.reply@lintac.cl';
+const MAX_BODY_CHARS = 3000;
+
+export class GmailScanner {
+  private readonly clientId: string;
+  private readonly clientSecret: string;
+  private readonly refreshToken: string;
+
+  constructor(clientId: string, clientSecret: string, refreshToken: string) {
+    this.clientId = clientId;
+    this.clientSecret = clientSecret;
+    this.refreshToken = refreshToken;
+  }
+
+  async fetchSchoolEmails(daysBack: number): Promise<SchoolEmail[]> {
+    const auth = new google.auth.OAuth2(this.clientId, this.clientSecret);
+    auth.setCredentials({ refresh_token: this.refreshToken });
+
+    const gmail = google.gmail({ version: 'v1', auth });
+    const query = `from:${SENDER} newer_than:${daysBack}d`;
+
+    const listRes = await gmail.users.messages.list({
+      userId: 'me',
+      q: query,
+      maxResults: 20,
+    });
+
+    const messages = listRes.data.messages ?? [];
+    const emails: SchoolEmail[] = [];
+
+    for (const msg of messages) {
+      if (!msg.id) continue;
+
+      const full = await gmail.users.messages.get({
+        userId: 'me',
+        id: msg.id,
+        format: 'full',
+      });
+
+      const headers: gmail_v1.Schema$MessagePartHeader[] = full.data.payload?.headers ?? [];
+      const subject = headers.find((h) => h.name?.toLowerCase() === 'subject')?.value ?? '(sin asunto)';
+      const dateHeader = headers.find((h) => h.name?.toLowerCase() === 'date')?.value ?? '';
+      const date = dateHeader ? new Date(dateHeader).toISOString().slice(0, 10) : 'unknown';
+
+      const body = extractBody(full.data.payload).slice(0, MAX_BODY_CHARS);
+      if (body) {
+        emails.push({ subject, date, body });
+      }
+    }
+
+    return emails;
+  }
+}
+
+function extractBody(payload: gmail_v1.Schema$MessagePart | null | undefined): string {
+  if (!payload) return '';
+
+  if (payload.mimeType === 'text/plain' && payload.body?.data) {
+    return Buffer.from(payload.body.data, 'base64url').toString('utf-8');
+  }
+
+  if (payload.parts) {
+    for (const part of payload.parts) {
+      if (part.mimeType === 'text/plain' && part.body?.data) {
+        return Buffer.from(part.body.data, 'base64url').toString('utf-8');
+      }
+    }
+    for (const part of payload.parts) {
+      if (part.mimeType === 'text/html' && part.body?.data) {
+        const html = Buffer.from(part.body.data, 'base64url').toString('utf-8');
+        return stripHtml(html);
+      }
+    }
+    for (const part of payload.parts) {
+      const nested = extractBody(part);
+      if (nested) return nested;
+    }
+  }
+
+  return '';
+}
+
+function stripHtml(html: string): string {
+  return html
+    .replace(/<style[^>]*>[\s\S]*?<\/style>/gi, '')
+    .replace(/<script[^>]*>[\s\S]*?<\/script>/gi, '')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/\s{2,}/g, ' ')
+    .trim();
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,9 @@ const app = createRoutes({
   waBucket: env.WA_AUTH_BUCKET,
   defaultWorkspaceId: env.WORKSPACE_ID,
   adminToken: env.ADMIN_TOKEN,
+  gmailClientId: env.GMAIL_CLIENT_ID,
+  gmailClientSecret: env.GMAIL_CLIENT_SECRET,
+  gmailRefreshToken: env.GMAIL_REFRESH_TOKEN,
 });
 
 const port = Number(env.PORT);

--- a/src/reminders/weekly.ts
+++ b/src/reminders/weekly.ts
@@ -3,6 +3,7 @@ import { toZonedTime } from 'date-fns-tz';
 import type { ReminderContext } from '../ai/message-generator.js';
 import { generateReminder } from '../ai/message-generator.js';
 import type { WorkspaceStore } from '../data/firestore.js';
+import type { GmailScanner } from '../gmail/scanner.js';
 import type { WhatsAppClient } from '../whatsapp/client.js';
 import { childLogger } from '../utils/logger.js';
 
@@ -19,6 +20,7 @@ export async function runWeeklyReminder(
   store: WorkspaceStore,
   waClient: WhatsAppClient,
   apiKey: string,
+  gmailScanner?: GmailScanner,
 ): Promise<WeeklyResult> {
   const config = await store.getConfig();
   const tz = config.timezone;
@@ -31,11 +33,17 @@ export async function runWeeklyReminder(
 
   log.info({ from: fromStr, to: toStr }, 'weekly.generating');
 
-  const [events, rotation, students, voiceExamples] = await Promise.all([
+  const [events, rotation, students, voiceExamples, schoolEmails] = await Promise.all([
     store.listEventsByDateRange(fromStr, toStr),
     store.getRotation(),
     store.listStudents(),
     store.listVoiceExamples(),
+    gmailScanner
+      ? gmailScanner.fetchSchoolEmails(7).catch((err: unknown) => {
+          log.warn({ err: String(err) }, 'gmail.fetch.failed');
+          return [];
+        })
+      : Promise.resolve([]),
   ]);
 
   const ctx: ReminderContext = {
@@ -46,6 +54,7 @@ export async function runWeeklyReminder(
     voiceExamples,
     className: config.className,
     schoolName: config.schoolName,
+    schoolEmails,
   };
 
   const message = await generateReminder(apiKey, ctx);

--- a/src/web/routes.ts
+++ b/src/web/routes.ts
@@ -7,6 +7,7 @@ import { runWeeklyReminder } from '../reminders/weekly.js';
 import { GcsAuthStore } from '../whatsapp/auth-store.js';
 import { WhatsAppClient } from '../whatsapp/client.js';
 import { childLogger } from '../utils/logger.js';
+import { GmailScanner } from '../gmail/scanner.js';
 import { renderAdminPage } from './admin-page.js';
 import { renderApprovePage } from './approve-page.js';
 
@@ -18,10 +19,17 @@ interface AppEnv {
   readonly waBucket: string;
   readonly defaultWorkspaceId: string;
   readonly adminToken: string;
+  readonly gmailClientId?: string;
+  readonly gmailClientSecret?: string;
+  readonly gmailRefreshToken?: string;
 }
 
 export function createRoutes(env: AppEnv): Hono {
   const app = new Hono();
+
+  const gmailScanner = env.gmailClientId && env.gmailClientSecret && env.gmailRefreshToken
+    ? new GmailScanner(env.gmailClientId, env.gmailClientSecret, env.gmailRefreshToken)
+    : undefined;
 
   app.get('/health', (c) => c.json({ status: 'ok' }));
 
@@ -36,7 +44,7 @@ export function createRoutes(env: AppEnv): Hono {
 
     try {
       const result = reminderType === 'weekly'
-        ? await runWeeklyReminder(store, waClient, env.apiKey)
+        ? await runWeeklyReminder(store, waClient, env.apiKey, gmailScanner)
         : await runDailyReminder(store, waClient, env.apiKey);
 
       if (result.skipped) {


### PR DESCRIPTION
## Summary

- Scans Gmail for emails from no.reply@lintac.cl and includes them in the weekly WhatsApp reminder
- Uses OAuth2 refresh token stored in Secret Manager (optional — bot works without it)
- One-time setup: npm run gmail-auth

## Secrets already provisioned in GCP

gmail-refresh-token, gmail-client-id, gmail-client-secret created in Secret Manager with IAM binding for room-bot-sa.

## Test plan

- [ ] Merge and deploy via bash infra/deploy.sh
- [ ] Trigger weekly reminder, verify school emails appear in WhatsApp draft