### PR TITLE
fix: increase MAX_TOKENS from 600 to 1200

### DIFF
--- a/src/ai/client.ts
+++ b/src/ai/client.ts
@@ -4,7 +4,7 @@ import { childLogger } from '../utils/logger.js';
 const log = childLogger('ai-client');
 
 const MODEL = 'claude-sonnet-4-6';
-const MAX_TOKENS = 600;
+const MAX_TOKENS = 1200;
 const MAX_RETRIES = 3;
 
 export async function generateMessage(


### PR DESCRIPTION
## Summary
- Weekly messages with school emails exceed 600 tokens and get cut off mid-sentence
- Increasing to 1200 gives enough room for: school emails + events + snack rotation + upcoming section

## Test plan
- [ ] Merge and deploy, re-run `/remind/generate` weekly — message should be complete