### PR TITLE
fix: swallow GCS upload error on disconnect

### DIFF
--- a/src/whatsapp/client.ts
+++ b/src/whatsapp/client.ts
@@ -137,8 +137,7 @@ export class WhatsAppClient {
     try {
       await this.authStore.upload();
     } catch (err) {
-      log.error({ err: String(err) }, 'wa.auth.upload.failed');
-      throw err;
+      log.warn({ err: String(err) }, 'wa.auth.upload.failed');
     }
 
     if (this.socket) {


### PR DESCRIPTION
GCS credential save fails after message is already sent. Logging as warn instead of rethrowing prevents a false 500 on successful sends.