### PR TITLE
feat: add event delete and add items to assigned event

### DIFF
--- a/src/data/firestore.ts
+++ b/src/data/firestore.ts
@@ -227,6 +227,67 @@ export class WorkspaceStore {
     await this.col('events').doc(id).update({ status });
   }
 
+  async deleteEvent(id: string): Promise<void> {
+    const doc = await this.col('events').doc(id).get();
+    if (!doc.exists) throw new Error('Event not found');
+    const status = doc.data()!['status'] as EventStatus;
+    if (status !== 'draft') throw new Error('Only draft events can be deleted');
+    await this.col('events').doc(id).delete();
+  }
+
+  async addItemsToAssignedEvent(eventId: string, newItems: { name: string }[]): Promise<ClassEvent> {
+    if (newItems.length === 0) throw new Error('No items provided');
+
+    const rotRef = this.db.doc(`workspaces/${this.workspaceId}/rotation/config`);
+    const eventRef = this.col('events').doc(eventId);
+
+    return this.db.runTransaction(async (tx) => {
+      const [rotDoc, eventDoc] = await Promise.all([tx.get(rotRef), tx.get(eventRef)]);
+      if (!rotDoc.exists) throw new Error('Rotation config not found');
+      if (!eventDoc.exists) throw new Error('Event not found');
+
+      const rot = rotDoc.data()!;
+      const event = eventDoc.data()!;
+      const existingItems = (event['items'] as EventItem[]) ?? [];
+
+      const order = rot['order'] as string[];
+      const deferred = [...((rot['deferred'] as string[] | undefined) ?? [])];
+      let currentIndex = rot['currentIndex'] as number;
+
+      const assigned: EventItem[] = [];
+      const usedFromDeferred: string[] = [];
+
+      for (const item of newItems) {
+        let studentId: string;
+        if (deferred.length > 0) {
+          studentId = deferred.shift()!;
+          usedFromDeferred.push(studentId);
+        } else {
+          studentId = order[currentIndex % order.length]!;
+          currentIndex = (currentIndex + 1) % order.length;
+        }
+        assigned.push({ name: item.name, assignedTo: studentId });
+      }
+
+      const updatedItems = [...existingItems, ...assigned];
+
+      tx.update(rotRef, {
+        currentIndex,
+        deferred: deferred.filter((d) => !usedFromDeferred.includes(d)),
+      });
+      tx.update(eventRef, { items: updatedItems });
+
+      return {
+        id: eventId,
+        date: event['date'] as string,
+        description: event['description'] as string,
+        type: event['type'] as EventType,
+        items: updatedItems,
+        status: event['status'] as EventStatus,
+      };
+    });
+  }
+
   // --- Drafts ---
 
   async createDraft(message: string, reminderType: ReminderType): Promise<string> {

--- a/src/web/admin-page.ts
+++ b/src/web/admin-page.ts
@@ -43,6 +43,25 @@ export function renderAdminPage(data: AdminData): string {
           ? `<button class="btn btn-primary" onclick="doAssign('${esc(e.id)}')">Asignar estudiantes</button>`
           : '';
 
+        const deleteBtn = e.status === 'draft'
+          ? `<button class="btn btn-danger" onclick="doDelete('${esc(e.id)}')">Eliminar</button>`
+          : '';
+
+        const addItemsBtn = e.status === 'assigned'
+          ? `<button class="btn btn-secondary" onclick="toggleAddItems('${esc(e.id)}')">+ Agregar items</button>
+             <div id="add-items-${esc(e.id)}" class="add-items-form" style="display:none">
+               <div id="new-items-${esc(e.id)}" class="items-builder">
+                 <div class="item-input">
+                   <input type="text" placeholder="Ej: Jugo, Galletas..." class="new-item-field">
+                   <button class="btn-sm btn-remove-item" onclick="removeNewItem(this)">X</button>
+                 </div>
+               </div>
+               <button class="btn-sm btn-add-item" onclick="addNewItem('${esc(e.id)}')" style="margin-top:4px">+ Agregar item</button>
+               <br>
+               <button class="btn btn-primary" onclick="doAddItems('${esc(e.id)}')" style="margin-top:8px">Guardar y asignar</button>
+             </div>`
+          : '';
+
         return `<div class="event-card" id="event-${esc(e.id)}">
           <div class="event-header">
             <span class="event-date">${esc(e.date)}</span>
@@ -52,6 +71,8 @@ export function renderAdminPage(data: AdminData): string {
           <p class="event-desc">${esc(e.description)}</p>
           <ul class="item-list">${itemRows}</ul>
           ${assignBtn}
+          ${addItemsBtn}
+          ${deleteBtn}
           <div id="msg-${esc(e.id)}" class="msg"></div>
         </div>`;
       }).join('\n');
@@ -206,6 +227,11 @@ export function renderAdminPage(data: AdminData): string {
     }
     .btn-add-item { background: #e0e0e0; color: #333; }
     .btn-remove-item { background: #ffcdd2; color: #c62828; min-width: 32px; }
+    .btn-danger { background: #f44336; color: white; margin-top: 8px; }
+    .btn-danger:hover { background: #d32f2f; }
+    .btn-secondary { background: #e0e0e0; color: #333; margin-top: 8px; }
+    .btn-secondary:hover { background: #bdbdbd; }
+    .add-items-form { margin-top: 10px; padding: 10px; background: #f9f9f9; border-radius: 6px; border: 1px solid #e0e0e0; }
   </style>
 </head>
 <body>
@@ -261,11 +287,12 @@ export function renderAdminPage(data: AdminData): string {
     const W = '${esc(workspaceId)}';
     const T = '${esc(token)}';
 
-    async function api(path, body) {
+    async function api(path, body, method) {
+      const m = method || 'POST';
       const res = await fetch(path + '?token=' + T, {
-        method: 'POST',
+        method: m,
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(body),
+        body: m === 'DELETE' ? undefined : JSON.stringify(body),
       });
       const data = await res.json();
       if (!res.ok) throw new Error(data.error || 'Error');
@@ -322,6 +349,55 @@ export function renderAdminPage(data: AdminData): string {
       if (container.children.length > 1) {
         btn.parentElement.remove();
       }
+    }
+
+    async function doDelete(eventId) {
+      if (!confirm('Eliminar este evento? Esta accion no se puede deshacer.')) return;
+      try {
+        await api('/admin/' + W + '/event/' + eventId, {}, 'DELETE');
+        showMsg('msg-' + eventId, true, 'Evento eliminado. Recargando...');
+        setTimeout(() => location.reload(), 1500);
+      } catch (err) { showMsg('msg-' + eventId, false, err.message); }
+    }
+
+    function toggleAddItems(eventId) {
+      const form = document.getElementById('add-items-' + eventId);
+      if (!form) return;
+      form.style.display = form.style.display === 'none' ? 'block' : 'none';
+    }
+
+    function addNewItem(eventId) {
+      const container = document.getElementById('new-items-' + eventId);
+      if (!container) return;
+      const div = document.createElement('div');
+      div.className = 'item-input';
+      div.innerHTML = '<input type="text" placeholder="Ej: Jugo, Galletas..." class="new-item-field">'
+        + '<button class="btn-sm btn-remove-item" onclick="removeNewItem(this)">X</button>';
+      container.appendChild(div);
+    }
+
+    function removeNewItem(btn) {
+      const container = btn.parentElement.parentElement;
+      if (container.children.length > 1) {
+        btn.parentElement.remove();
+      }
+    }
+
+    async function doAddItems(eventId) {
+      const container = document.getElementById('new-items-' + eventId);
+      if (!container) return;
+      const fields = container.querySelectorAll('.new-item-field');
+      const items = [];
+      fields.forEach(function(f) {
+        const val = f.value.trim();
+        if (val) items.push({ name: val });
+      });
+      if (items.length === 0) { showMsg('msg-' + eventId, false, 'Agrega al menos un item'); return; }
+      try {
+        await api('/admin/' + W + '/event/' + eventId + '/items', { items });
+        showMsg('msg-' + eventId, true, 'Items agregados y asignados. Recargando...');
+        setTimeout(() => location.reload(), 1500);
+      } catch (err) { showMsg('msg-' + eventId, false, err.message); }
     }
 
     async function doAddEvent() {

--- a/src/web/routes.ts
+++ b/src/web/routes.ts
@@ -246,6 +246,51 @@ export function createRoutes(env: AppEnv): Hono {
     }
   });
 
+  app.delete('/admin/:workspaceId/event/:eventId', async (c) => {
+    const token = c.req.query('token') ?? '';
+    if (token !== env.adminToken) {
+      return c.json({ error: 'No autorizado' }, 401);
+    }
+
+    const workspaceId = c.req.param('workspaceId');
+    const eventId = c.req.param('eventId');
+    const store = new WorkspaceStore(env.db, workspaceId);
+
+    try {
+      await store.deleteEvent(eventId);
+      log.info({ eventId, workspaceId }, 'admin.event.deleted');
+      return c.json({ status: 'deleted' });
+    } catch (err) {
+      log.error({ err: String(err), eventId }, 'admin.event.delete.failed');
+      return c.json({ error: String(err) }, 400);
+    }
+  });
+
+  app.post('/admin/:workspaceId/event/:eventId/items', async (c) => {
+    const token = c.req.query('token') ?? '';
+    if (token !== env.adminToken) {
+      return c.json({ error: 'No autorizado' }, 401);
+    }
+
+    const workspaceId = c.req.param('workspaceId');
+    const eventId = c.req.param('eventId');
+    const body = await c.req.json() as { items?: { name: string }[] };
+
+    if (!body.items || body.items.length === 0) {
+      return c.json({ error: 'items is required and must not be empty' }, 400);
+    }
+
+    const store = new WorkspaceStore(env.db, workspaceId);
+    try {
+      const event = await store.addItemsToAssignedEvent(eventId, body.items);
+      log.info({ eventId, workspaceId, added: body.items.length }, 'admin.event.items.added');
+      return c.json({ status: 'items_added', event });
+    } catch (err) {
+      log.error({ err: String(err), eventId }, 'admin.event.items.add.failed');
+      return c.json({ error: String(err) }, 400);
+    }
+  });
+
   app.post('/admin/:workspaceId/event/:eventId/assign', async (c) => {
     const token = c.req.query('token') ?? '';
     if (token !== env.adminToken) {


### PR DESCRIPTION
## Summary
- Add **Eliminar** button (draft events only) → calls `DELETE /admin/:w/event/:id`
- Add **+ Agregar items** button (assigned events) → inline form that assigns new items to next students in rotation without touching existing assignments
- `addItemsToAssignedEvent` runs in a Firestore transaction, same pattern as `assignStudentsToEvent`

## Test plan
- [ ] Create a draft event → Eliminar button appears → click → event deleted
- [ ] Create and assign an event → "+ Agregar items" button appears → add 2 items → verify they appear assigned to next students in rotation
- [ ] Verify deferred students are prioritized when adding items to assigned event
- [ ] Try deleting an assigned event → should fail with error message